### PR TITLE
Make MonoBridges utility final

### DIFF
--- a/src/main/java/reactor/core/publisher/MonoBridges.java
+++ b/src/main/java/reactor/core/publisher/MonoBridges.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
  *
  * @author DoHyung Kim
  */
-class MonoBridges {
+final class MonoBridges {
 
     static Mono<Void> when(Publisher<Void>[] sources) {
         return Mono.when(sources);


### PR DESCRIPTION
Follow the usual convention of making a utility class final in order to
prevent accidental subclassing