### PR TITLE
fix: Prevent runtime failure in MonoFunctions#whenComplete

### DIFF
--- a/src/main/java/reactor/kotlin/core/publisher/MonoBridges.java
+++ b/src/main/java/reactor/kotlin/core/publisher/MonoBridges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,15 @@ final class MonoBridges {
 	}
 
 	static Mono<Void> when(Publisher<?>[] sources) {
-		return Mono.when(sources);
+		Publisher<?>[] tmp = sources;
+		// Ensure the Java array is Publisher[] and not a more specific subtype array.
+		// Kotlin's Array(1) { TestPublisher.create<Void>() } would result in TestPublisher[] at runtime
+		// and as a consequence fail since the internal operator logic can modify the array and wrap the Publisher
+		// instances as Mono.
+		if (!(sources.getClass().getComponentType().isAssignableFrom(Publisher.class))) {
+			tmp = new Publisher[sources.length];
+			System.arraycopy(sources, 0, tmp, 0, sources.length);
+		}
+		return Mono.when(tmp);
 	}
 }


### PR DESCRIPTION
Avoids `java.lang.ArrayStoreException` with reactor-core 3.6+ which replaces elements in an array of Publishers. In Kotlin it is easy to instantiate a more specific array by accident and not notice a problem until it throws during operation. The fix creates a copy into a Publisher[] in case the array is more specific.